### PR TITLE
Make Serial.open accept a `Ports` object as well as the ports name

### DIFF
--- a/lib/Serial.ts
+++ b/lib/Serial.ts
@@ -30,15 +30,17 @@ export class Serial {
 
     /**
      * Opens the serial connection.
-     * @param {string} port The port to connect
+     * @param {string|Ports} port The port to connect
      * @param {number} baudrate The baudrate
      * @param {SerialOptions} serialOptions Additional options for the serial connection (`data bits`, `parity`, `stop bits`)
      */
     open(
-        port : string,
+        port : string | Ports,
         baudrate : number,
         serialOptions? : SerialOptions
     ) : number {
+        // It's just the ports name that is interesting to us
+        if(typeof port != "string") port = port.name;
         const status = this._dl.open(
             port,
             baudrate,

--- a/lib/errors/error_code.ts
+++ b/lib/errors/error_code.ts
@@ -2,7 +2,7 @@ import { statusCodes } from "../constants/status_codes.ts";
 
 export class ErrorCode extends Error {
     constructor(code : number) {
-        const errorCodeKey = Object.keys(statusCodes).find(key => statusCodes[key] === code);
+        const errorCodeKey = Object.entries(statusCodes).find(([_,value]) => value === code)?.[0];
         super(`An error has occurred. Error code: ${errorCodeKey} (${code})`);
     }
 }


### PR DESCRIPTION
Please. I want to be able to write:
```ts
serial.open(availablePorts[1], baudrate.B9600);
```
without always having to write
```ts
serial.open(availablePorts[1].name, baudrate.B9600);
```
because that would not make any sense to me